### PR TITLE
Merge RESTful API for customer, employee and orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,21 +5,18 @@ It is our course project for COP 5725. ORM model is
 not used due to the course requirement.
 
 # Evironment setup
-Install requirements
+1. Install requirements
 ```
 pip install -r requirements.txt
 ```
-Configure Oracle Instant Client following [ODPI-C Installation](https://oracle.github.io/odpi/doc/installation.html#macos)
+2. Configure Oracle Instant Client following [ODPI-C Installation](https://oracle.github.io/odpi/doc/installation.html#macos)
 
-Then (otherwise you cannot run the tests)
+3. Setup and run a few tests
 ```
 python setup.py develop
-```
-Run a few tests
-```
 pytest
 ```
-Then start the server with
+4. Start the server with
 ```
 flask run
 ```

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Install requirements
 ```
 pip install -r requirements.txt
 ```
+Configure Oracle Instant Client following [ODPI-C Installation](https://oracle.github.io/odpi/doc/installation.html#macos)
+
 Then (otherwise you cannot run the tests)
 ```
 python setup.py develop

--- a/app/routes.py
+++ b/app/routes.py
@@ -4,8 +4,11 @@ from datetime import datetime
 
 from app import app
 from app.forms import LoginForm
-
+# import views
 from .views.overview import overview
+# from .views.customer import customer
+# from .views.employee import employee
+# from .views.order import order
 from app.models import User, user_loader
 from app.db import get_db
 

--- a/app/views/customer.py
+++ b/app/views/customer.py
@@ -1,0 +1,137 @@
+from app import app
+from bokeh.embed import components
+from bokeh.plotting import figure
+from bokeh.resources import INLINE
+from flask import render_template, flash, redirect, url_for, request, jsonify
+from flask_login import current_user, login_user, logout_user, login_required
+from datetime import datetime
+
+from app.db import get_db
+
+
+@app.route('/customer', methods=['GET', 'POST'])
+@login_required
+def customer():
+    pass
+
+# restful api
+@app.route('/api/customer_by_geo', methods=['GET'])
+def customer_by_geo():
+    """
+    Return the customer numbers for each zipcode.
+    """
+    db = get_db()
+    cur = db.cursor()
+    rows = list(cur.execute(
+        f"""
+        select count(customer.customerID) as num, city.zipcode as zipcode
+        from customer, city
+        where customer.city = city.cityID
+        group by city.zipcode)"""))
+    data = []
+    for row in rows:
+        data.append({'cat_name': row[0], 'revenue': row[1]})
+    return jsonify(data)
+
+@app.route('/api/repeat_order_by_time', methods=['GET'])
+def repeat_order_by_time():
+    """
+    Return the number of repeated purchases (same prodcut > 3 times)
+    and the total number of orders for different category with the time range.
+    """
+    date_start = request.args.get('date_start')
+    date_end = request.args.get('date_end')
+    db = get_db()
+    cur = db.cursor()
+    rows = list(cur.execute(
+        f"""
+        with orders as 
+            (select sales.customerID as customer_id, productcategory.name as category, sales.salesID as salesID
+             from customer, sales, product, productcategory
+             where salesdate between to_date({date_start}, 'YYYYMMDD') and to_date({date_end}, 'YYYYMMDD')
+                and customer.customerID = sales.customerID
+                and sales.productID = product.productID
+                    and product.categoryID = productcategory.categoryID)
+        select avg(number_total), sum(number_repeat) as repeat, cat1 as category
+        from (select count(salesID) as number_total, category as cat1
+              from orders
+              group by category
+             )
+             inner join
+             (select count(salesID) as number_repeat, category as cat2
+              from orders
+              group by customer_id, category
+              having count(salesID) > 3
+             )
+            on cat1 = cat2
+        group by cat1"""))
+    # the reason use avg(number_total) is after the group by, 
+    # for the same category, each row has same value for number_total
+    data = []
+    for row in rows:
+        data.append({'cat_name': row[0], 'revenue': row[1]})
+    return jsonify(data)
+
+# 需要给 customer table 添加随机性别，可以使用 excel 完成
+@app.route('/api/num_order_by_gender_cat', methods=['GET'])
+def num_order_by_age_cat():
+    """
+    Return the number of male and female purchasing orders for each category in time range.
+    """
+    date_start = request.args.get('date_start')
+    date_end = request.args.get('date_end')
+    db = get_db()
+    cur = db.cursor()
+    rows = list(cur.execute(
+        f"""
+        select count(saleID) as order_num, customer.gender as gender, productcategory.name as category
+        from customer, sales, product, productcategory
+        where salesdate between to_date({date_start}, 'YYYYMMDD') and to_date({date_end}, 'YYYYMMDD')
+            and customer.customerID = sales.customerID
+            and sales.productID = product.productID
+            and product.categoryID = productcategory.categoryID)
+        group by productcategory.name, customer.gender"""))
+    data = []
+    for row in rows:
+        data.append({'cat_name': row[0], 'revenue': row[1]})
+    return jsonify(data)
+
+# 需要 zipcode 的范围确定东西南北，大致确定
+@app.route('/api/num_order_by_geo', methods=['GET'])
+def num_order_by_geo():
+    """
+    Return the number of orders in different geo region for each category in time range.
+    """
+    date_start = request.args.get('date_start')
+    date_end = request.args.get('date_end')
+    db = get_db()
+    cur = db.cursor()
+    rows = list(cur.execute(
+        f"""
+        with geo as
+           (select count(saleID) as order_num, city.zipcode as zipcode, productcategory.name as category
+            from customer, sales, product, productcategory, city
+            where salesdate between to_date({date_start}, 'YYYYMMDD') and to_date({date_end}, 'YYYYMMDD')
+                and customer.customerID = sales.customerID
+                and sales.productID = product.productID
+                and product.categoryID = productcategory.categoryID
+                and customer.city = city.cityID)
+            group by productcategory.name, city.zipcode)
+        select region.range as [region], count(*) as [order_num], category
+        from (select case  
+              when zipcode between 0 and 19999 then 'Northeast'
+              when zipcode between 20000 and 29999 then 'East'
+              when zipcode between 30000 and 39999 then 'Southeast'
+              when zipcode between 40000 and 59999 then 'North'
+              when zipcode between 70000 and 79999 then 'South'
+              when zipcode between 88900 and 95000 then 'West'
+              when zipcode between 95001 and 96999 then 'Southwest'
+              when zipcode between 97000 and 9999 then 'Nouthwest'
+              else 'Middle' end as range
+              from geo) region
+        group by region.range, category
+        """))
+    data = []
+    for row in rows:
+        data.append({'cat_name': row[0], 'revenue': row[1]})
+    return jsonify(data)

--- a/app/views/customer.py
+++ b/app/views/customer.py
@@ -74,7 +74,7 @@ def repeat_order_by_time():
 
 # 需要给 customer table 添加随机性别，可以使用 excel 完成
 @app.route('/api/num_order_by_gender_cat', methods=['GET'])
-def num_order_by_age_cat():
+def num_order_by_gender_cat():
     """
     Return the number of male and female purchasing orders for each category in time range.
     """

--- a/app/views/customer.py
+++ b/app/views/customer.py
@@ -27,10 +27,10 @@ def customer_by_geo():
         select count(customer.customerID) as num, city.zipcode as zipcode
         from customer, city
         where customer.city = city.cityID
-        group by city.zipcode)"""))
+        group by city.zipcode"""))
     data = []
     for row in rows:
-        data.append({'cat_name': row[0], 'revenue': row[1]})
+        data.append({'number': row[0], 'zipcode': row[1]})
     return jsonify(data)
 
 @app.route('/api/repeat_order_by_time', methods=['GET'])
@@ -69,7 +69,7 @@ def repeat_order_by_time():
     # for the same category, each row has same value for number_total
     data = []
     for row in rows:
-        data.append({'cat_name': row[0], 'revenue': row[1]})
+        data.append({'category': row[2], 'total orders': row[0], 'repeated orders': row[1]})
     return jsonify(data)
 
 # 需要给 customer table 添加随机性别，可以使用 excel 完成
@@ -93,7 +93,7 @@ def num_order_by_gender_cat():
         group by productcategory.name, customer.gender"""))
     data = []
     for row in rows:
-        data.append({'cat_name': row[0], 'revenue': row[1]})
+        data.append({'category': row[2], 'order number': row[0], 'gender': row[1]})
     return jsonify(data)
 
 # 需要 zipcode 的范围确定东西南北，大致确定
@@ -133,5 +133,5 @@ def num_order_by_geo():
         """))
     data = []
     for row in rows:
-        data.append({'cat_name': row[0], 'revenue': row[1]})
+        data.append({'category': row[2], 'region': row[0], 'order number': row[1]})
     return jsonify(data)

--- a/app/views/employee.py
+++ b/app/views/employee.py
@@ -34,11 +34,11 @@ def best_employee():
               group by employee.name
               order by sum(sales.total) desc)
         where rownum = 1"""))
-    data = dict(best_product=rows[0][0])
+    data = dict(best_employee=rows[0][0])
     return jsonify(data)
 
 @app.route('/api/avg_selling_per', methods=['GET'])
-def avg_selling_product():
+def avg_selling_per():
     """
     Return the average order numbers of each employee within the time range.
     """
@@ -55,13 +55,13 @@ def avg_selling_product():
                   and sales.employeeID = employee.employeeID
               group by employee.name
               order by count(sales.salesID) desc)"""))
-    data = dict(best_product=rows[0][0])
+    data = dict(avg_selling_per=rows[0][0])
     return jsonify(data)
 
 @app.route('/api/num_order_by_employee', methods=['GET'])
-def avg_selling_product():
+def num_order_by_employee():
     """
-    Return the average order numbers of each employee within the time range.
+    Return the order numbers and revenue of each employee within the time range.
     """
     date_start = request.args.get('date_start')
     date_end = request.args.get('date_end')
@@ -74,10 +74,10 @@ def avg_selling_product():
         where salesdate between to_date({date_start}, 'YYYYMMDD') and to_date({date_end}, 'YYYYMMDD')
             and sales.employeeID = employee.employeeID
         group by employee.name
-        order by count(sales.salesID) desc)"""))
+        order by count(sales.salesID) desc"""))
     data = []
     for row in rows:
-        data.append({'cat_name': row[0], 'revenue': row[1]})
+        data.append({'employee': row[0], 'order numbers': row[1], 'revenue': row[2]})
     return jsonify(data)
 
 # optional and under construction
@@ -100,5 +100,5 @@ def top5_employee_monthly():
         order by sum(sales.salesID) desc)"""))
     data = []
     for row in rows:
-        data.append({'cat_name': row[0], 'revenue': row[1]})
+        data.append({'employee': row[0], 'order number': row[1], 'revenue': row[2]})
     return jsonify(data)

--- a/app/views/employee.py
+++ b/app/views/employee.py
@@ -1,0 +1,104 @@
+from app import app
+from bokeh.embed import components
+from bokeh.plotting import figure
+from bokeh.resources import INLINE
+from flask import render_template, flash, redirect, url_for, request, jsonify
+from flask_login import current_user, login_user, logout_user, login_required
+from datetime import datetime
+
+from app.db import get_db
+
+
+@app.route('/employee', methods=['GET', 'POST'])
+@login_required
+def employee():
+    pass
+
+# restful api
+@app.route('/api/best_employee', methods=['GET'])
+def best_employee():
+    """
+    Return the best seller employee ranked by total revenue within the time range.
+    """
+    date_start = request.args.get('date_start')
+    date_end = request.args.get('date_end')
+    db = get_db()
+    cur = db.cursor()
+    rows = list(cur.execute(
+        f"""
+        select name
+        from (select employee.name as name, sum(sales.total)
+              from sales, employee
+              where salesdate between to_date({date_start}, 'YYYYMMDD') and to_date({date_end}, 'YYYYMMDD')
+                  and sales.employeeID = employee.employeeID
+              group by employee.name
+              order by sum(sales.total) desc)
+        where rownum = 1"""))
+    data = dict(best_product=rows[0][0])
+    return jsonify(data)
+
+@app.route('/api/avg_selling_per', methods=['GET'])
+def avg_selling_product():
+    """
+    Return the average order numbers of each employee within the time range.
+    """
+    date_start = request.args.get('date_start')
+    date_end = request.args.get('date_end')
+    db = get_db()
+    cur = db.cursor()
+    rows = list(cur.execute(
+        f"""
+        select sum(order_num) / count(name)
+        from (select count(sales.salesID) as order_num, employee.name as name
+              from sales, employee
+              where salesdate between to_date({date_start}, 'YYYYMMDD') and to_date({date_end}, 'YYYYMMDD')
+                  and sales.employeeID = employee.employeeID
+              group by employee.name
+              order by count(sales.salesID) desc)"""))
+    data = dict(best_product=rows[0][0])
+    return jsonify(data)
+
+@app.route('/api/num_order_by_employee', methods=['GET'])
+def avg_selling_product():
+    """
+    Return the average order numbers of each employee within the time range.
+    """
+    date_start = request.args.get('date_start')
+    date_end = request.args.get('date_end')
+    db = get_db()
+    cur = db.cursor()
+    rows = list(cur.execute(
+        f"""
+        select employee.name as name, count(sales.salesID) as order_number, sum(sales.total) as revenue
+        from sales, employee
+        where salesdate between to_date({date_start}, 'YYYYMMDD') and to_date({date_end}, 'YYYYMMDD')
+            and sales.employeeID = employee.employeeID
+        group by employee.name
+        order by count(sales.salesID) desc)"""))
+    data = []
+    for row in rows:
+        data.append({'cat_name': row[0], 'revenue': row[1]})
+    return jsonify(data)
+
+# optional and under construction
+@app.route('/api/top5_employee_monthly', methods=['GET'])
+def top5_employee_monthly():
+    """
+    Return the monthly order numbers and revenue trending of 2018 year top 5 employee ranked by revenue.
+    """
+    date_start = 20180101
+    date_end = 20181231
+    db = get_db()
+    cur = db.cursor()
+    rows = list(cur.execute(
+        f"""
+        select employee.name as name, count(sales.salesID) as order_number, sum(sales.total) as revenue
+        from sales, employee
+        where salesdate between to_date({date_start}, 'YYYYMMDD') and to_date({date_end}, 'YYYYMMDD')
+            and sales.employeeID = employee.employeeID
+        group by employee.name
+        order by sum(sales.salesID) desc)"""))
+    data = []
+    for row in rows:
+        data.append({'cat_name': row[0], 'revenue': row[1]})
+    return jsonify(data)

--- a/app/views/order.py
+++ b/app/views/order.py
@@ -1,0 +1,101 @@
+from app import app
+from bokeh.embed import components
+from bokeh.plotting import figure
+from bokeh.resources import INLINE
+from flask import render_template, flash, redirect, url_for, request, jsonify
+from flask_login import current_user, login_user, logout_user, login_required
+from datetime import datetime
+
+from app.db import get_db
+
+
+@app.route('/order', methods=['GET', 'POST'])
+@login_required
+def order():
+    pass
+
+# restful api
+@app.route('/api/best_product', methods=['GET'])
+def best_product():
+    """
+    Return the best selling product rank by total revenue within the time range.
+    """
+    date_start = request.args.get('date_start')
+    date_end = request.args.get('date_end')
+    db = get_db()
+    cur = db.cursor()
+    rows = list(cur.execute(
+        f"""
+        select productname
+        from (select productname, count(sales.salesID)
+              from sales, product
+              where salesdate between to_date({date_start}, 'YYYYMMDD') and to_date({date_end}, 'YYYYMMDD')
+                  and sales.productID = product.productID
+              group by product.PRODUCTNAME
+              order by count(sales.salesID) desc)
+        where rownum = 1"""))
+    data = dict(best_product=rows[0][0])
+    return jsonify(data)
+
+@app.route('/api/avg_price', methods=['GET'])
+def avg_price():
+    """
+    Return the average selling price of all orders within given time range.
+    """
+    date_start = request.args.get('date_start')
+    date_end = request.args.get('date_end')
+    db = get_db()
+    cur = db.cursor()
+    rows = list(cur.execute(
+        f"""
+        select sum / cnt
+        from (select count(salesID) as cnt, sum(total) as sum
+              from sales
+              where salesdate between to_date({date_start}, 'YYYYMMDD') and to_date({date_end}, 'YYYYMMDD'))"""))
+    data = dict(avg_price=rows[0][0])
+    return jsonify(data)
+
+@app.route('/api/num_order_by_cat', methods=['GET'])
+def num_order_by_cat():
+    """
+    Return the order numbers for each category within the time range.
+    """
+    date_start = request.args.get('date_start')
+    date_end = request.args.get('date_end')
+    db = get_db()
+    cur = db.cursor()
+    rows = cur.execute(
+        f"""
+        select productcategory.name, count(salesID)
+        from sales, product, productcategory
+        where salesdate between to_date({date_start}, 'YYYYMMDD') and to_date({date_end}, 'YYYYMMDD')
+            and sales.productID = product.productID
+            and product.categoryID = productcategory.categoryID
+        group by productcategory.name
+        order by count(salesID) desc""")
+    data = []
+    for row in rows:
+        data.append({'cat_name': row[0], 'revenue': row[1]})
+    return jsonify(data)
+
+@app.route('/api/max_avg_min_price_by_cat', methods=['GET'])
+def max_avg_min_price_by_cat():
+    """
+    Return the max, average and minimum price for each category within the time range.
+    """
+    date_start = request.args.get('date_start')
+    date_end = request.args.get('date_end')
+    db = get_db()
+    cur = db.cursor()
+    rows = cur.execute(
+        f"""
+        select productcategory.name as category, max(price) as max, avg(price) as avg, min(price) as min
+        from sales, product, productcategory
+        where salesdate between to_date({date_start}, 'YYYYMMDD') and to_date({date_end}, 'YYYYMMDD')
+            and sales.productID = product.productID
+            group by product.PRODUCTNAME
+        group by productcategory.name""")
+    data = []
+    for row in rows:
+        data.append({'cat_name': row[0], 'revenue': row[1]})
+    return jsonify(data)

--- a/app/views/order.py
+++ b/app/views/order.py
@@ -8,11 +8,12 @@ from datetime import datetime
 
 from app.db import get_db
 
-
+'''
 @app.route('/order', methods=['GET', 'POST'])
 @login_required
 def order():
     pass
+'''
 
 # restful api
 @app.route('/api/best_product', methods=['GET'])
@@ -75,7 +76,7 @@ def num_order_by_cat():
         order by count(salesID) desc""")
     data = []
     for row in rows:
-        data.append({'cat_name': row[0], 'revenue': row[1]})
+        data.append({'category': row[0], 'order number': row[1]})
     return jsonify(data)
 
 @app.route('/api/max_avg_min_price_by_cat', methods=['GET'])
@@ -93,9 +94,8 @@ def max_avg_min_price_by_cat():
         from sales, product, productcategory
         where salesdate between to_date({date_start}, 'YYYYMMDD') and to_date({date_end}, 'YYYYMMDD')
             and sales.productID = product.productID
-            group by product.PRODUCTNAME
         group by productcategory.name""")
     data = []
     for row in rows:
-        data.append({'cat_name': row[0], 'revenue': row[1]})
+        data.append({'category': row[0], 'max price': row[1], 'avg price': row[2], 'min price': row[3]})
     return jsonify(data)

--- a/app/views/overview.py
+++ b/app/views/overview.py
@@ -8,6 +8,7 @@ from datetime import datetime
 
 from app.db import get_db
 
+
 @app.route('/overview', methods=['GET', 'POST'])
 @login_required
 def overview():
@@ -15,14 +16,14 @@ def overview():
 
     if app.debug:
         print(request.form)
-    
+
     # date_start = request.form['date_start']
     # date_end = request.form['date_end']
     # if date_start == '':
-    date_start='1234-11-11'
+    date_start = '1234-11-11'
     # if date_end == '':
-    date_end='4321-11-11'
-    
+    date_end = '4321-11-11'
+
     # init a basic bar chart:
     # http://bokeh.pydata.org/en/latest/docs/user_guide/plotting.html#bars
     rev_fig = figure(sizing_mode='scale_width')
@@ -34,7 +35,7 @@ def overview():
         color='navy'
     )
     trend_script, trend_div = components(rev_fig)
-    
+
     cat_fig = figure(sizing_mode='scale_width')
     cat_fig.vbar(
         x=[1, 2, 3, 4],
@@ -53,7 +54,6 @@ def overview():
     total_sales = 123123
     total_orders = 321321
 
-    
     html = render_template(
         'overview.html',
         trend_script=trend_script,
@@ -69,6 +69,7 @@ def overview():
     )
     return html
 
+# restful api
 @app.route('/api/total_orders', methods=['GET'])
 def total_orders():
     """
@@ -78,10 +79,12 @@ def total_orders():
     date_end = request.args.get('date_end')
     db = get_db()
     cur = db.cursor()
-    rows = list(cur.execute(f"select count(*) from sales where salesdate between to_date({date_start}, 'YYYYMMDD') and to_date({date_end}, 'YYYYMMDD')"))
+    rows = list(cur.execute(
+        f"select count(*) from sales where salesdate between to_date({date_start}, 'YYYYMMDD') and to_date({date_end}, 'YYYYMMDD')"))
     print(rows)
-    data = dict(total_orders = rows[0][0])
+    data = dict(total_orders=rows[0][0])
     return jsonify(data)
+
 
 @app.route('/api/total_revenue', methods=['GET'])
 def total_revenue():
@@ -92,10 +95,12 @@ def total_revenue():
     date_end = request.args.get('date_end')
     db = get_db()
     cur = db.cursor()
-    rows = list(cur.execute(f"select sum(total) from sales where salesdate between to_date({date_start}, 'YYYYMMDD') and to_date({date_end}, 'YYYYMMDD')"))
+    rows = list(cur.execute(
+        f"select sum(total) from sales where salesdate between to_date({date_start}, 'YYYYMMDD') and to_date({date_end}, 'YYYYMMDD')"))
     print(rows)
-    data = dict(total_revenue = rows[0][0])
+    data = dict(total_revenue=rows[0][0])
     return jsonify(data)
+
 
 @app.route('/api/revenue_by_time', methods=['GET'])
 def revenue_by_time():
@@ -106,11 +111,13 @@ def revenue_by_time():
     date_end = request.args.get('date_end')
     db = get_db()
     cur = db.cursor()
-    rows = cur.execute(f"select salesdate, sum(total) from sales where salesdate between to_date({date_start}, 'YYYYMMDD') and to_date({date_end}, 'YYYYMMDD') group by salesdate order by salesdate")
+    rows = cur.execute(
+        f"select salesdate, sum(total) from sales where salesdate between to_date({date_start}, 'YYYYMMDD') and to_date({date_end}, 'YYYYMMDD') group by salesdate order by salesdate")
     data = []
     for row in rows:
         data.append({'salesdate': row[0], 'revenue': row[1]})
     return jsonify(data)
+
 
 @app.route('/api/revenue_by_cat', methods=['GET'])
 def revenue_by_cat():
@@ -123,13 +130,13 @@ def revenue_by_cat():
     cur = db.cursor()
     rows = cur.execute(
         f"""
-        select productcategory.name, sum(sales.total) 
+        select productcategory.name, sum(sales.total)
         from sales, product, productcategory
-        where salesdate between to_date({date_start}, 'YYYYMMDD') and to_date({date_end}, 'YYYYMMDD') 
-            and sales.productID = product.productID 
+        where salesdate between to_date({date_start}, 'YYYYMMDD') and to_date({date_end}, 'YYYYMMDD')
+            and sales.productID = product.productID
             and product.productID = productcategory.categoryID
         group by productcategory.name
-        order by sum(sales.total) desc""")  
+        order by sum(sales.total) desc""")
     data = []
     for row in rows:
         data.append({'cat_name': row[0], 'revenue': row[1]})

--- a/app/views/overview.py
+++ b/app/views/overview.py
@@ -139,5 +139,6 @@ def revenue_by_cat():
         order by sum(sales.total) desc""")
     data = []
     for row in rows:
-        data.append({'cat_name': row[0], 'revenue': row[1]})
+        data.append({'category': row[0], 'revenue': row[1]})
     return jsonify(data)
+


### PR DESCRIPTION
1. Four api for each page has been implemented.
2. The **individual chart for each employee during several months query** has been replaced to a fixed **monthly oder number and revenue trending of 2018 year for top 5 sellers ranked by revenue**. This api still has some problem and under construction.
3. It is difficult to add the random age to customer table, while gender is easier and not affect the data distribution so much. Thus I remove the option **number of orders by age distribution**, but we need to update the customer table with random gender. This can be done by several ways:
- excel: `=CHOOSE(RANDBETWEEN(1,2),"Male","Female")`
- python: `random.choice(["Male","Female"])`
4. Customer geo may be implemented using [zipcodeAPI](https://www.zipcodeapi.com) and the region range I believe still need more carefully adjustment.